### PR TITLE
Multi-Fieldtype tag parsing processes conditionals

### DIFF
--- a/ee2/third_party/fieldpack/fieldpack_fieldtype.php
+++ b/ee2/third_party/fieldpack/fieldpack_fieldtype.php
@@ -627,13 +627,14 @@ class Fieldpack_Multi_Fieldtype extends Fieldpack_Fieldtype {
 					// copy $tagdata
 					$option_tagdata = $tagdata;
 
-					// simple var swaps
-					$option_tagdata = $this->EE->TMPL->swap_var_single('option', $option, $option_tagdata);
-					$option_tagdata = $this->EE->TMPL->swap_var_single('option_name', $option_name, $option_tagdata);
 
-					// seems there was a mix-up in the documentation and things where ambiguous. Let's make it crystal clear.
-					$option_tagdata = $this->EE->TMPL->swap_var_single('option_value', $option_name, $option_tagdata);
-					$option_tagdata = $this->EE->TMPL->swap_var_single('option_label', $option, $option_tagdata);
+					// this will replace the tags and parse conditionals
+					$option_tagdata = $this->EE->TMPL->parse_variables_row($option_tagdata, array(
+						'option' => $option,
+						'option_name' => $option_name,
+						'option_value' => $option_name,
+						'option_label' => $option,
+					));
 
 					// parse {switch} and {count} tags
 					$this->parse_iterators($option_tagdata);


### PR DESCRIPTION
I needed to replace the tag parsing in the Fieldpack_Multi_Fieldtype class to make sure that EE processes the conditional statements correctly in more recent versions. This relates to Derek Jones' note here: https://support.ellislab.com/bugs/detail/20437/#13179

This is a cleaner version of a solution suggested in PR #4.
